### PR TITLE
feat: Add frontend dev tooling; fix containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   redis:
     image: redis:latest
@@ -10,7 +8,6 @@ services:
 
   postgres:
     image: postgres:15
-    container_name: nexus-postgres
     ports:
       - "5432:5432"
     environment:

--- a/docs/FRONTEND_DEVELOPMENT.md
+++ b/docs/FRONTEND_DEVELOPMENT.md
@@ -1,0 +1,267 @@
+# Frontend Development Guide
+
+This guide helps frontend engineers work on the Nexus Agents UI without needing API keys, MCP servers, or the full backend stack.
+
+## Quick Start for Frontend Engineers
+
+### Step 1: Get Sample Data
+
+Ask a colleague to share their data/db_export/ folder:
+```bash
+python scripts/export_data.py
+```
+
+### Step 2: Import Data to Local PostgreSQL
+
+Import the exported data into your local PostgreSQL:
+```bash
+python scripts/import_data.py
+```
+
+### Step 3: Start Services
+
+Start all services in read-only mode (no worker/Redis/MCP/LLM keys required):
+```bash
+./scripts/start_dev.sh --read-only
+```
+Or start all services (full development mode):
+```bash
+./scripts/start_dev.sh
+```
+
+### Step 4: Access the UI
+
+- **Web UI**: http://localhost:12001
+- **API Docs**: http://localhost:12000/docs
+
+### Step 5: Stop Services
+
+Stop all services:
+```bash
+./scripts/stop_dev.sh
+```
+
+## Data Export/Import Scripts
+
+### Export Data (`scripts/export_data.py`)
+
+Exports current PostgreSQL data to JSON files in `data/db_export/`:
+
+Export data from your development database:
+```bash
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nexus_agents"
+python scripts/export_data.py
+```
+
+**Exported Files:**
+- `research_tasks.json` - All research tasks with metadata
+- `task_operations.json` - Operation timeline data
+- `operation_evidence.json` - Evidence and search results
+- `artifacts.json` - Research reports and files
+- `research_subtasks.json` - Task decomposition data
+- `sources.json` - External source references
+- `export_metadata.json` - Export metadata and checksums
+
+### Import Data (`scripts/import_data.py`)
+
+Imports JSON files back into PostgreSQL:
+
+Import exported data to a fresh database:
+```bash
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nexus_agents"
+python scripts/import_data.py
+```
+
+**Note:** This will clear existing data before importing.
+
+
+
+## Frontend Structure
+
+```
+frontend/
+├── index.html              # Main HTML page
+├── css/
+│   ├── components.css      # Component styles
+│   └── themes.css          # Light/dark theme styles
+└── js/
+    ├── main.js             # Application initialization
+    ├── modules/
+    │   ├── tasks.js        # Task management functions
+    │   ├── renderer.js     # UI rendering utilities
+    │   └── polling.js      # Data polling and updates
+    └── lib/
+        └── json-viewer/    # JSON tree viewer component
+```
+
+## Key Frontend Features
+
+### Task Management
+- **Task Cards**: Collapsible cards showing task details
+- **Status Badges**: Color-coded status indicators
+- **Timeline View**: Expandable operation timeline with JSON trees
+- **Evidence Summary**: Statistics on search providers and evidence items
+
+### Research Reports
+- **Markdown Rendering**: Full research reports in modal dialogs
+- **Report Metadata**: Word count, timestamps, export options
+
+### Theme Support
+- **Light/Dark Toggle**: Site-wide theme switching
+- **JSON Viewer Theming**: Color-coded JSON trees that adapt to theme
+
+### Real-time Updates
+- **Auto-polling**: Automatic refresh of task status and data
+- **State Preservation**: Maintains expanded/collapsed states during updates
+
+## API Integration
+
+The frontend expects these API response formats:
+
+### Task List (`GET /tasks`)
+```json
+[
+  {
+    "task_id": "uuid",
+    "title": "Task Title", 
+    "description": "Description",
+    "status": "completed|running|pending|failed",
+    "created_at": "2024-01-01T00:00:00",
+    "updated_at": "2024-01-01T00:00:00",
+    "completed_at": "2024-01-01T00:00:00"
+  }
+]
+```
+
+### Task Operations (`GET /tasks/{id}/operations`)
+```json
+{
+  "operations": [
+    {
+      "operation_id": "uuid",
+      "task_id": "uuid", 
+      "operation_type": "search|planning|synthesis",
+      "operation_name": "Human readable name",
+      "status": "completed|running|pending|failed",
+      "agent_type": "search_agent|planning_agent", 
+      "started_at": "2024-01-01T00:00:00",
+      "completed_at": "2024-01-01T00:00:00",
+      "duration_ms": 5000,
+      "input_data": { "query": "..." },
+      "output_data": { "results": "..." }
+    }
+  ]
+}
+```
+
+### Task Evidence (`GET /tasks/{id}/evidence`)
+```json
+{
+  "evidence": [...],
+  "operations": [...],
+  "statistics": {
+    "evidence_items": 42,
+    "search_providers_used": ["openai", "mcp_search"],
+    "operations_count": 5
+  }
+}
+```
+
+## Development Workflow
+
+### 1. Setup
+```bash
+# Clone and setup
+git clone <repo>
+cd nexus-agents
+
+# Install dependencies
+uv sync
+```
+
+### 2. Get Sample Data
+```bash
+# Option A: Export from existing database
+python scripts/export_data.py
+
+# Option B: Ask a colleague to share their data/db_export/ folder
+```
+
+### 3. Start Development
+```bash
+# Import sample data
+python scripts/import_data.py
+
+# Start services in read-only mode
+./scripts/start_dev.sh --read-only
+
+# Access the UI at http://localhost:12001
+```
+
+### 4. Frontend Development
+- Edit files in `frontend/`
+- Refresh browser to see changes
+- Use browser dev tools for debugging
+- API provides realistic data from imported database
+
+### 5. Testing with Full Backend
+```bash
+# Start all services (including worker for task processing)
+./scripts/start_dev.sh
+
+# Now you can create and process tasks end-to-end
+```
+
+### 6. Stop Services
+```bash
+# Stop all services when done
+./scripts/stop_dev.sh
+```
+
+## Troubleshooting
+
+### Service Issues
+- **Port conflicts**: Services run on ports 12000 (API) and 12001 (Web UI)
+- **Services won't start**: Check logs in `logs/` directory for errors
+- **PostgreSQL connection**: Ensure PostgreSQL is running with `docker compose ps`
+
+### Frontend Issues
+- **API calls failing**: Check if services are running with `./scripts/start_dev.sh --read-only`
+- **Styles not loading**: Check file paths and Web UI server
+- **JavaScript errors**: Check browser console for detailed error messages
+
+### Database Issues
+- **Import fails**: Ensure PostgreSQL is running and schema exists
+- **Connection errors**: Check PostgreSQL connection in `.env` file
+- **Permission errors**: Ensure database user has sufficient privileges
+
+## Contributing
+
+When making frontend changes:
+
+1. **Start with Read-Only Mode**: Use `./scripts/start_dev.sh --read-only` for development
+2. **Test with Imported Data**: Import sample data for realistic testing
+3. **Check Responsive Design**: Test on different screen sizes
+4. **Verify Theme Support**: Check both light and dark themes
+5. **Document Changes**: Update this guide if adding new features
+
+## Environment Variables
+
+For the export/import scripts:
+
+```bash
+# Database connection (for export/import scripts)
+export DATABASE_URL="postgresql://user:password@host:port/database"
+
+# For full backend development (not needed for frontend-only mode)
+export OPENAI_API_KEY="your-key"
+export REDIS_URL="redis://localhost:6379"
+```
+
+## Getting Help
+
+- **Frontend Issues**: Check browser console and network tab
+- **API Issues**: Check logs in `logs/api.log` and `logs/web.log`
+- **Service Issues**: Check `logs/` directory for all service logs
+- **Database Issues**: Check PostgreSQL logs with `docker compose logs postgres`
+- **General Setup**: Refer to main README.md for full development setup

--- a/scripts/export_data.py
+++ b/scripts/export_data.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Export PostgreSQL data to JSON files for frontend development.
+
+This script exports all task data from PostgreSQL to JSON files that can be
+used by frontend engineers without needing API keys or running the full backend.
+"""
+import asyncio
+import asyncpg
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    print("⚠️  python-dotenv not installed, using environment variables only")
+
+
+async def export_data():
+    """Export all relevant data from PostgreSQL to JSON files."""
+    
+    # Get database connection info from environment
+    # Prioritize individual POSTGRES_* variables from .env over DATABASE_URL
+    host = os.getenv("POSTGRES_HOST")
+    port = os.getenv("POSTGRES_PORT")
+    db = os.getenv("POSTGRES_DB")
+    user = os.getenv("POSTGRES_USER")
+    password = os.getenv("POSTGRES_PASSWORD")
+    
+    # If individual variables are set, use them
+    if host and user and password:
+        port = port or "5432"
+        db = db or "nexus_agents"
+        db_url = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+        print(f"Using individual POSTGRES_* variables from .env")
+    else:
+        # Fall back to DATABASE_URL if individual variables not set
+        db_url = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/nexus_agents")
+        print(f"Using DATABASE_URL environment variable")
+    
+    # Redact password for display
+    display_url = db_url.split('@')[0].split(':')[:-1] + ["[REDACTED]"] + ['@' + db_url.split('@')[1]] if '@' in db_url else [db_url]
+    
+    print(f"Connecting to database: {''.join(display_url)}")
+    
+    try:
+        conn = await asyncpg.connect(db_url)
+        print("✅ Connected to PostgreSQL")
+        
+        # Create export directory
+        export_dir = Path("data/db_export")
+        export_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Export research_tasks
+        print("📦 Exporting research_tasks...")
+        tasks = await conn.fetch("SELECT * FROM research_tasks ORDER BY created_at DESC")
+        tasks_data = []
+        for task in tasks:
+            task_dict = dict(task)
+            # Convert datetime objects to ISO strings
+            for key, value in task_dict.items():
+                if isinstance(value, datetime):
+                    task_dict[key] = value.isoformat()
+            tasks_data.append(task_dict)
+        
+        with open(export_dir / "research_tasks.json", "w") as f:
+            json.dump(tasks_data, f, indent=2, default=str)
+        print(f"   Exported {len(tasks_data)} tasks")
+        
+        # Export task_operations
+        print("📦 Exporting task_operations...")
+        operations = await conn.fetch("SELECT * FROM task_operations ORDER BY started_at DESC")
+        operations_data = []
+        for op in operations:
+            op_dict = dict(op)
+            # Convert datetime objects to ISO strings
+            for key, value in op_dict.items():
+                if isinstance(value, datetime):
+                    op_dict[key] = value.isoformat()
+            operations_data.append(op_dict)
+        
+        with open(export_dir / "task_operations.json", "w") as f:
+            json.dump(operations_data, f, indent=2, default=str)
+        print(f"   Exported {len(operations_data)} operations")
+        
+        # Export operation_evidence
+        print("📦 Exporting operation_evidence...")
+        evidence = await conn.fetch("SELECT * FROM operation_evidence ORDER BY created_at DESC")
+        evidence_data = []
+        for ev in evidence:
+            ev_dict = dict(ev)
+            # Convert datetime objects to ISO strings
+            for key, value in ev_dict.items():
+                if isinstance(value, datetime):
+                    ev_dict[key] = value.isoformat()
+            evidence_data.append(ev_dict)
+        
+        with open(export_dir / "operation_evidence.json", "w") as f:
+            json.dump(evidence_data, f, indent=2, default=str)
+        print(f"   Exported {len(evidence_data)} evidence items")
+        
+        # Export artifacts (research reports)
+        print("📦 Exporting artifacts...")
+        artifacts = await conn.fetch("SELECT * FROM artifacts ORDER BY created_at DESC")
+        artifacts_data = []
+        for artifact in artifacts:
+            artifact_dict = dict(artifact)
+            # Convert datetime objects to ISO strings
+            for key, value in artifact_dict.items():
+                if isinstance(value, datetime):
+                    artifact_dict[key] = value.isoformat()
+            artifacts_data.append(artifact_dict)
+        
+        with open(export_dir / "artifacts.json", "w") as f:
+            json.dump(artifacts_data, f, indent=2, default=str)
+        print(f"   Exported {len(artifacts_data)} artifacts")
+        
+        # Export research_subtasks
+        print("📦 Exporting research_subtasks...")
+        subtasks = await conn.fetch("SELECT * FROM research_subtasks ORDER BY created_at DESC")
+        subtasks_data = []
+        for subtask in subtasks:
+            subtask_dict = dict(subtask)
+            # Convert datetime objects to ISO strings
+            for key, value in subtask_dict.items():
+                if isinstance(value, datetime):
+                    subtask_dict[key] = value.isoformat()
+            subtasks_data.append(subtask_dict)
+        
+        with open(export_dir / "research_subtasks.json", "w") as f:
+            json.dump(subtasks_data, f, indent=2, default=str)
+        print(f"   Exported {len(subtasks_data)} subtasks")
+        
+        # Export sources
+        print("📦 Exporting sources...")
+        sources = await conn.fetch("SELECT * FROM sources ORDER BY accessed_at DESC")
+        sources_data = []
+        for source in sources:
+            source_dict = dict(source)
+            # Convert datetime objects to ISO strings
+            for key, value in source_dict.items():
+                if isinstance(value, datetime):
+                    source_dict[key] = value.isoformat()
+            sources_data.append(source_dict)
+        
+        with open(export_dir / "sources.json", "w") as f:
+            json.dump(sources_data, f, indent=2, default=str)
+        print(f"   Exported {len(sources_data)} sources")
+        
+        # Create export metadata
+        metadata = {
+            "export_timestamp": datetime.utcnow().isoformat(),
+            "tables_exported": {
+                "research_tasks": len(tasks_data),
+                "task_operations": len(operations_data),
+                "operation_evidence": len(evidence_data),
+                "artifacts": len(artifacts_data),
+                "research_subtasks": len(subtasks_data),
+                "sources": len(sources_data)
+            },
+            "database_url": db_url.split('@')[0] + "@[REDACTED]",  # Hide credentials
+            "export_version": "1.0"
+        }
+        
+        with open(export_dir / "export_metadata.json", "w") as f:
+            json.dump(metadata, f, indent=2)
+        
+        print(f"\n✅ Export completed successfully!")
+        print(f"📁 Data exported to: {export_dir.absolute()}")
+        print(f"📊 Total items: {sum(metadata['tables_exported'].values())}")
+        
+    except Exception as e:
+        print(f"❌ Export failed: {e}")
+        return False
+    
+    finally:
+        if 'conn' in locals():
+            await conn.close()
+    
+    return True
+
+
+if __name__ == "__main__":
+    import sys
+    
+    # Check if DATABASE_URL is set
+    if not os.getenv("DATABASE_URL"):
+        print("⚠️  DATABASE_URL environment variable not set.")
+        print("   Please set it to your PostgreSQL connection string:")
+        print("   export DATABASE_URL='postgresql://user:password@host:port/database'")
+        sys.exit(1)
+    
+    # Run the export
+    success = asyncio.run(export_data())
+    sys.exit(0 if success else 1)

--- a/scripts/import_data.py
+++ b/scripts/import_data.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Import JSON data files back into PostgreSQL for frontend development.
+
+This script imports exported JSON data into a fresh PostgreSQL instance,
+allowing teams to restore realistic test data.
+"""
+import asyncio
+import asyncpg
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    print("⚠️  python-dotenv not installed, using environment variables only")
+
+
+async def import_data():
+    """Import JSON data files into PostgreSQL."""
+    
+    # Get database connection info from environment
+    # Prioritize individual POSTGRES_* variables from .env over DATABASE_URL
+    host = os.getenv("POSTGRES_HOST")
+    port = os.getenv("POSTGRES_PORT")
+    db = os.getenv("POSTGRES_DB")
+    user = os.getenv("POSTGRES_USER")
+    password = os.getenv("POSTGRES_PASSWORD")
+    
+    # If individual variables are set, use them
+    if host and user and password:
+        port = port or "5432"
+        db = db or "nexus_agents"
+        db_url = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+        print(f"Using individual POSTGRES_* variables from .env")
+    else:
+        # Fall back to DATABASE_URL if individual variables not set
+        db_url = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/nexus_agents")
+        print(f"Using DATABASE_URL environment variable")
+    
+    # Redact password for display
+    display_url = db_url.split('@')[0].split(':')[:-1] + ["[REDACTED]"] + ['@' + db_url.split('@')[1]] if '@' in db_url else [db_url]
+    
+    print(f"Connecting to database: {''.join(display_url)}")
+    
+    # Check if export data exists
+    export_dir = Path("data/db_export")
+    if not export_dir.exists():
+        print(f"❌ Export directory not found: {export_dir.absolute()}")
+        print("   Please run scripts/export_data.py first")
+        return False
+    
+    metadata_file = export_dir / "export_metadata.json"
+    if not metadata_file.exists():
+        print(f"❌ Export metadata not found: {metadata_file}")
+        return False
+    
+    # Load metadata
+    with open(metadata_file, "r") as f:
+        metadata = json.load(f)
+    
+    print(f"📦 Found export from {metadata['export_timestamp']}")
+    print(f"📊 Tables to import: {metadata['tables_exported']}")
+    
+    try:
+        conn = await asyncpg.connect(db_url)
+        print("✅ Connected to PostgreSQL")
+        
+        # Check if tables exist (they should be created by the schema)
+        tables_to_check = [
+            'research_tasks', 'task_operations', 'operation_evidence', 
+            'artifacts', 'research_subtasks', 'sources'
+        ]
+        
+        for table in tables_to_check:
+            exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $1)", 
+                table
+            )
+            if not exists:
+                print(f"❌ Table {table} does not exist. Please run schema creation first.")
+                return False
+        
+        print("✅ All required tables exist")
+        
+        # Clear existing data (optional - comment out if you want to append)
+        print("🧹 Clearing existing data...")
+        for table in reversed(tables_to_check):  # Reverse order to handle foreign keys
+            count = await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+            if count > 0:
+                await conn.execute(f"DELETE FROM {table}")
+                print(f"   Cleared {count} rows from {table}")
+        
+        # Import research_tasks
+        tasks_file = export_dir / "research_tasks.json"
+        if tasks_file.exists():
+            print("📥 Importing research_tasks...")
+            with open(tasks_file, "r") as f:
+                tasks_data = json.load(f)
+            
+            for task in tasks_data:
+                await conn.execute("""
+                    INSERT INTO research_tasks (
+                        task_id, title, description, research_query, status, 
+                        created_at, updated_at, completed_at, metadata, 
+                        decomposition, plan, results, summary, reasoning
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                """, 
+                    task['task_id'], task['title'], task['description'], 
+                    task.get('research_query'), task['status'],
+                    datetime.fromisoformat(task['created_at']) if task.get('created_at') else None,
+                    datetime.fromisoformat(task['updated_at']) if task.get('updated_at') else None,
+                    datetime.fromisoformat(task['completed_at']) if task.get('completed_at') else None,
+                    task.get('metadata'),  # Already JSON string from export
+                    task.get('decomposition'),  # Already JSON string from export
+                    task.get('plan'),  # Already JSON string from export
+                    task.get('results'),  # Already JSON string from export
+                    task.get('summary'),  # Already JSON string from export
+                    task.get('reasoning')  # Already JSON string from export
+                )
+            print(f"   Imported {len(tasks_data)} tasks")
+        
+        # Import task_operations
+        operations_file = export_dir / "task_operations.json"
+        if operations_file.exists():
+            print("📥 Importing task_operations...")
+            with open(operations_file, "r") as f:
+                operations_data = json.load(f)
+            
+            for op in operations_data:
+                await conn.execute("""
+                    INSERT INTO task_operations (
+                        operation_id, task_id, operation_type, operation_name, status,
+                        agent_type, started_at, completed_at, duration_ms,
+                        input_data, output_data, error_message, metadata
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                """,
+                    op['operation_id'], op['task_id'], op['operation_type'], 
+                    op['operation_name'], op['status'], op.get('agent_type'),
+                    datetime.fromisoformat(op['started_at']) if op.get('started_at') else None,
+                    datetime.fromisoformat(op['completed_at']) if op.get('completed_at') else None,
+                    op.get('duration_ms'),
+                    op.get('input_data'),  # Already JSON string from export
+                    op.get('output_data'),  # Already JSON string from export
+                    op.get('error_message'),
+                    op.get('metadata')  # Already JSON string from export
+                )
+            print(f"   Imported {len(operations_data)} operations")
+        
+        # Import operation_evidence
+        evidence_file = export_dir / "operation_evidence.json"
+        if evidence_file.exists():
+            print("📥 Importing operation_evidence...")
+            with open(evidence_file, "r") as f:
+                evidence_data = json.load(f)
+            
+            for ev in evidence_data:
+                await conn.execute("""
+                    INSERT INTO operation_evidence (
+                        evidence_id, operation_id, evidence_type, evidence_data,
+                        source_url, provider, created_at, size_bytes, metadata
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                """,
+                    ev['evidence_id'], ev['operation_id'], ev['evidence_type'],
+                    ev.get('evidence_data'),  # Already JSON string from export
+                    ev.get('source_url'), ev.get('provider'),
+                    datetime.fromisoformat(ev['created_at']) if ev.get('created_at') else None,
+                    ev.get('size_bytes'),
+                    ev.get('metadata')  # Already JSON string from export
+                )
+            print(f"   Imported {len(evidence_data)} evidence items")
+        
+        # Import artifacts
+        artifacts_file = export_dir / "artifacts.json"
+        if artifacts_file.exists():
+            print("📥 Importing artifacts...")
+            with open(artifacts_file, "r") as f:
+                artifacts_data = json.load(f)
+            
+            for artifact in artifacts_data:
+                await conn.execute("""
+                    INSERT INTO artifacts (
+                        artifact_id, task_id, subtask_id, title, type, format,
+                        file_path, content, metadata, created_at, updated_at,
+                        size_bytes, checksum
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                """,
+                    artifact['artifact_id'], artifact.get('task_id'), artifact.get('subtask_id'),
+                    artifact['title'], artifact['type'], artifact['format'],
+                    artifact.get('file_path'),
+                    artifact.get('content'),  # Already JSON string from export
+                    artifact.get('metadata'),  # Already JSON string from export
+                    datetime.fromisoformat(artifact['created_at']) if artifact.get('created_at') else None,
+                    datetime.fromisoformat(artifact['updated_at']) if artifact.get('updated_at') else None,
+                    artifact.get('size_bytes'), artifact.get('checksum')
+                )
+            print(f"   Imported {len(artifacts_data)} artifacts")
+        
+        print(f"\n✅ Import completed successfully!")
+        print(f"📊 Data restored from export: {metadata['export_timestamp']}")
+        
+    except Exception as e:
+        print(f"❌ Import failed: {e}")
+        return False
+    
+    finally:
+        if 'conn' in locals():
+            await conn.close()
+    
+    return True
+
+
+if __name__ == "__main__":
+    import sys
+    
+    # Check if DATABASE_URL is set
+    if not os.getenv("DATABASE_URL"):
+        print("⚠️  DATABASE_URL environment variable not set.")
+        print("   Please set it to your PostgreSQL connection string:")
+        print("   export DATABASE_URL='postgresql://user:password@host:port/database'")
+        sys.exit(1)
+    
+    # Run the import
+    success = asyncio.run(import_data())
+    sys.exit(0 if success else 1)

--- a/scripts/mock_api_server.py
+++ b/scripts/mock_api_server.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+Mock API server for frontend development.
+
+This server serves exported JSON data directly, allowing frontend engineers
+to work without needing PostgreSQL, Redis, or API keys.
+"""
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+
+app = FastAPI(title="Nexus Agents Mock API", version="1.0.0")
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Allow all origins for development
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Global data storage
+_data = {
+    "tasks": [],
+    "operations": [],
+    "evidence": [],
+    "artifacts": [],
+    "subtasks": [],
+    "sources": []
+}
+
+
+def load_export_data():
+    """Load exported JSON data into memory."""
+    export_dir = Path("data/db_export")
+    
+    if not export_dir.exists():
+        print(f"⚠️  Export directory not found: {export_dir.absolute()}")
+        print("   Please run scripts/export_data.py first")
+        return False
+    
+    # Load metadata
+    metadata_file = export_dir / "export_metadata.json"
+    if metadata_file.exists():
+        with open(metadata_file, "r") as f:
+            metadata = json.load(f)
+        print(f"📦 Loading export from {metadata['export_timestamp']}")
+    
+    # Load each data file
+    data_files = {
+        "tasks": "research_tasks.json",
+        "operations": "task_operations.json", 
+        "evidence": "operation_evidence.json",
+        "artifacts": "artifacts.json",
+        "subtasks": "research_subtasks.json",
+        "sources": "sources.json"
+    }
+    
+    for key, filename in data_files.items():
+        file_path = export_dir / filename
+        if file_path.exists():
+            with open(file_path, "r") as f:
+                _data[key] = json.load(f)
+            print(f"   Loaded {len(_data[key])} {key}")
+        else:
+            print(f"   ⚠️  {filename} not found, using empty data")
+            _data[key] = []
+    
+    print(f"✅ Mock API data loaded successfully!")
+    return True
+
+
+# API Routes
+
+@app.get("/")
+async def root():
+    """Health check endpoint."""
+    return {
+        "message": "Nexus Agents Mock API Server",
+        "version": "1.0.0",
+        "status": "running",
+        "data_loaded": {
+            "tasks": len(_data["tasks"]),
+            "operations": len(_data["operations"]),
+            "evidence": len(_data["evidence"]),
+            "artifacts": len(_data["artifacts"]),
+            "subtasks": len(_data["subtasks"]),
+            "sources": len(_data["sources"])
+        }
+    }
+
+
+@app.get("/tasks")
+async def get_tasks():
+    """Get all research tasks."""
+    return _data["tasks"]
+
+
+@app.get("/tasks/{task_id}")
+async def get_task(task_id: str):
+    """Get a specific task by ID."""
+    task = next((t for t in _data["tasks"] if t["task_id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return task
+
+
+@app.get("/tasks/{task_id}/operations")
+async def get_task_operations(task_id: str):
+    """Get operations for a specific task."""
+    # Check if task exists
+    task = next((t for t in _data["tasks"] if t["task_id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    
+    # Get operations for this task
+    task_operations = [op for op in _data["operations"] if op["task_id"] == task_id]
+    
+    # Return in the expected format
+    return {
+        "operations": task_operations,
+        "timeline": task_operations  # Frontend expects both formats
+    }
+
+
+@app.get("/tasks/{task_id}/evidence")
+async def get_task_evidence(task_id: str):
+    """Get evidence for a specific task."""
+    # Check if task exists
+    task = next((t for t in _data["tasks"] if t["task_id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    
+    # Get operations for this task
+    task_operations = [op for op in _data["operations"] if op["task_id"] == task_id]
+    operation_ids = [op["operation_id"] for op in task_operations]
+    
+    # Get evidence for these operations
+    task_evidence = [ev for ev in _data["evidence"] if ev["operation_id"] in operation_ids]
+    
+    # Calculate statistics
+    search_providers = set()
+    evidence_items = len(task_evidence)
+    
+    for evidence in task_evidence:
+        if evidence.get("provider"):
+            search_providers.add(evidence["provider"])
+    
+    return {
+        "evidence": task_evidence,
+        "operations": task_operations,
+        "statistics": {
+            "evidence_items": evidence_items,
+            "search_providers_used": list(search_providers),
+            "operations_count": len(task_operations)
+        }
+    }
+
+
+@app.get("/api/research/tasks/{task_id}/report")
+async def get_research_report(task_id: str):
+    """Get research report for a task."""
+    # Check if task exists
+    task = next((t for t in _data["tasks"] if t["task_id"] == task_id), None)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    
+    # Look for report artifact
+    report_artifact = next(
+        (a for a in _data["artifacts"] 
+         if a["task_id"] == task_id and a["type"] == "report"),
+        None
+    )
+    
+    if report_artifact and report_artifact.get("content"):
+        # If we have a report artifact, return its content
+        content = report_artifact["content"]
+        if isinstance(content, dict) and "markdown" in content:
+            return JSONResponse(content=content["markdown"], media_type="text/plain")
+        elif isinstance(content, str):
+            return JSONResponse(content=content, media_type="text/plain")
+    
+    # Generate a mock report if no artifact exists
+    mock_report = f"""# Research Report: {task.get('title', 'Untitled Task')}
+
+## Overview
+This is a mock research report generated for frontend development purposes.
+
+**Task ID:** {task_id}
+**Status:** {task.get('status', 'unknown')}
+**Created:** {task.get('created_at', 'unknown')}
+
+## Summary
+{task.get('description', 'No description available')}
+
+## Key Findings
+- Mock finding 1: This is simulated research data
+- Mock finding 2: Used for frontend development without backend
+- Mock finding 3: Generated from exported database content
+
+## Methodology
+This report was generated using the mock API server for frontend development.
+The actual research workflow would include real agent analysis and data gathering.
+
+## Conclusion
+This mock report demonstrates the research report display functionality
+in the Nexus Agents frontend interface.
+
+---
+*Generated by Mock API Server for Development*"""
+
+    return JSONResponse(content=mock_report, media_type="text/plain")
+
+
+@app.post("/tasks")
+async def create_task(task_data: dict):
+    """Create a new task (mock implementation)."""
+    # Generate a mock task ID
+    task_id = f"mock-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    
+    new_task = {
+        "task_id": task_id,
+        "title": task_data.get("title", "Mock Task"),
+        "description": task_data.get("description", "Mock task for frontend development"),
+        "research_query": task_data.get("description"),
+        "status": "pending",
+        "created_at": datetime.now().isoformat(),
+        "updated_at": datetime.now().isoformat(),
+        "completed_at": None,
+        "metadata": task_data.get("metadata"),
+        "decomposition": None,
+        "plan": None,
+        "results": None,
+        "summary": None,
+        "reasoning": None
+    }
+    
+    # Add to mock data
+    _data["tasks"].insert(0, new_task)  # Insert at beginning for newest-first order
+    
+    return new_task
+
+
+@app.delete("/tasks/{task_id}")
+async def delete_task(task_id: str):
+    """Delete a task (mock implementation)."""
+    # Find and remove task
+    task_index = next((i for i, t in enumerate(_data["tasks"]) if t["task_id"] == task_id), None)
+    if task_index is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    
+    # Remove task and related data
+    _data["tasks"].pop(task_index)
+    _data["operations"] = [op for op in _data["operations"] if op["task_id"] != task_id]
+    _data["artifacts"] = [a for a in _data["artifacts"] if a["task_id"] != task_id]
+    _data["subtasks"] = [s for s in _data["subtasks"] if s["task_id"] != task_id]
+    
+    # Remove evidence for removed operations
+    remaining_operation_ids = [op["operation_id"] for op in _data["operations"]]
+    _data["evidence"] = [ev for ev in _data["evidence"] if ev["operation_id"] in remaining_operation_ids]
+    
+    return {"message": f"Task {task_id} deleted successfully"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    
+    # Load data on startup
+    if not load_export_data():
+        print("❌ Failed to load export data. Server will run with empty data.")
+        print("   Run scripts/export_data.py first to generate test data.")
+    
+    print("\n🚀 Starting Mock API Server...")
+    print("📡 API will be available at: http://localhost:12000")
+    print("📖 API docs at: http://localhost:12000/docs")
+    print("🔄 Use this instead of the real backend for frontend development")
+    
+    uvicorn.run(app, host="0.0.0.0", port=12000)

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -9,7 +9,16 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo -e "${GREEN}Starting Nexus Agents Development Environment...${NC}"
+# Parse command line arguments
+READ_ONLY=false
+if [ "$1" = "--read-only" ]; then
+    READ_ONLY=true
+    echo -e "${GREEN}Starting Nexus Agents Development Environment (Read-Only Mode)...${NC}"
+    echo -e "${YELLOW}This mode starts PostgreSQL, API backend, and Web UI${NC}"
+    echo -e "${YELLOW}No Redis, worker, or MCP servers - you can view imported data but not create new tasks${NC}"
+else
+    echo -e "${GREEN}Starting Nexus Agents Development Environment...${NC}"
+fi
 
 # Function to check if a command exists
 command_exists() {
@@ -67,63 +76,81 @@ else
     echo -e "${YELLOW}Warning: .env file not found. Using default values.${NC}"
 fi
 
-# Start Redis
-echo -e "\n${YELLOW}Starting Redis...${NC}"
+# Start Redis (skip in frontend-only mode)
+echo -e "\n${YELLOW}Starting database services...${NC}"
 REDIS_STARTED=false
-
-if command_exists docker && docker info >/dev/null 2>&1; then
-    # Test if Redis is actually functional, not just port availability
-    if redis-cli ping >/dev/null 2>&1; then
+if [ "$READ_ONLY" = true ]; then
+    echo -e "${YELLOW}Skipping Redis startup (read-only mode)${NC}"
+    # Start only PostgreSQL
+    if command_exists docker && docker info >/dev/null 2>&1; then
+        if docker compose ps postgres | grep -q "running"; then
+            echo "PostgreSQL container already running"
+        else
+            echo "Starting PostgreSQL using Docker Compose..."
+            docker compose up -d postgres >/dev/null 2>&1
+        fi
+    else
+        echo -e "${YELLOW}Warning: PostgreSQL not found. Please ensure it's running manually.${NC}"
+    fi
+else
+    # Full mode - start both Redis and PostgreSQL
+    if command_exists docker && docker info >/dev/null 2>&1; then
+        if docker compose ps redis | grep -q "running"; then
+            echo "Redis container already running"
+            REDIS_STARTED=true
+        else
+            echo "Starting Redis and PostgreSQL using Docker Compose..."
+            docker compose up -d redis postgres >/dev/null 2>&1
+            REDIS_STARTED=true
+        fi
+    elif command_exists redis-server; then
+        # Test if Redis is actually functional, not just port availability
+        if redis-cli ping >/dev/null 2>&1; then
+            echo "Redis already running and responding"
+            REDIS_STARTED=true
+        else
+            echo "Starting local Redis server..."
+            redis-server --daemonize yes
+            REDIS_STARTED=true
+        fi
+    elif redis-cli ping >/dev/null 2>&1; then
         echo "Redis already running and responding"
         REDIS_STARTED=true
     else
-        echo "Starting Redis and PostgreSQL using Docker Compose..."
-        docker compose up -d redis postgres >/dev/null 2>&1
-        REDIS_STARTED=true
+        echo -e "${RED}Error: Redis is required but not available.${NC}"
+        echo -e "${YELLOW}Please install Redis using one of these methods:${NC}"
+        echo "  1. Install Docker Desktop and ensure it's running"
+        echo "  2. Install Redis locally:"
+        echo "     - macOS: brew install redis"
+        echo "     - Ubuntu/Debian: sudo apt-get install redis-server"
+        echo "     - Other: https://redis.io/download"
+        exit 1
     fi
-elif command_exists redis-server; then
-    # Test if Redis is actually functional, not just port availability
-    if redis-cli ping >/dev/null 2>&1; then
-        echo "Redis already running and responding"
-        REDIS_STARTED=true
+
+    # Wait for Redis to be ready
+    if [ "$REDIS_STARTED" = true ]; then
+        wait_for_service "Redis" "redis-cli ping >/dev/null 2>&1"
+    fi
+fi
+
+# Setup MCP servers if needed (skip in read-only mode)
+if [ "$READ_ONLY" = false ]; then
+    echo -e "\n${YELLOW}Checking MCP servers...${NC}"
+    if [ ! -d "external_mcp_servers/firecrawl-mcp" ] || [ ! -d "external_mcp_servers/exa-mcp" ]; then
+        echo "MCP servers not found. Running setup script..."
+        ./scripts/setup_mcp_servers.sh
     else
-        echo "Starting local Redis server..."
-        redis-server --daemonize yes
-        REDIS_STARTED=true
+        echo "MCP servers already set up"
     fi
-elif redis-cli ping >/dev/null 2>&1; then
-    echo "Redis already running and responding"
-    REDIS_STARTED=true
+
+    # Validate MCP setup
+    echo -e "\n${YELLOW}Validating MCP setup...${NC}"
+    uv run python scripts/validate_mcp_setup.py || {
+        echo -e "${YELLOW}Warning: MCP validation failed. Some features may not work.${NC}"
+    }
 else
-    echo -e "${RED}Error: Redis is required but not available.${NC}"
-    echo -e "${YELLOW}Please install Redis using one of these methods:${NC}"
-    echo "  1. Install Docker Desktop and ensure it's running"
-    echo "  2. Install Redis locally:"
-    echo "     - macOS: brew install redis"
-    echo "     - Ubuntu/Debian: sudo apt-get install redis-server"
-    echo "     - Other: https://redis.io/download"
-    exit 1
+    echo -e "\n${YELLOW}Skipping MCP servers setup (read-only mode)${NC}"
 fi
-
-# Wait for Redis to be ready
-if [ "$REDIS_STARTED" = true ]; then
-    wait_for_service "Redis" "redis-cli ping >/dev/null 2>&1"
-fi
-
-# Setup MCP servers if needed
-echo -e "\n${YELLOW}Checking MCP servers...${NC}"
-if [ ! -d "external_mcp_servers/firecrawl-mcp" ] || [ ! -d "external_mcp_servers/exa-mcp" ]; then
-    echo "MCP servers not found. Running setup script..."
-    ./scripts/setup_mcp_servers.sh
-else
-    echo "MCP servers already set up"
-fi
-
-# Validate MCP setup
-echo -e "\n${YELLOW}Validating MCP setup...${NC}"
-uv run python scripts/validate_mcp_setup.py || {
-    echo -e "${YELLOW}Warning: MCP validation failed. Some features may not work.${NC}"
-}
 
 # Create necessary directories
 echo -e "\n${YELLOW}Creating necessary directories...${NC}"
@@ -149,11 +176,16 @@ echo "API backend PID: $API_PID"
 # Wait for API to be ready
 wait_for_service "API backend" "curl -s http://localhost:12000/docs >/dev/null 2>&1"
 
-# Start worker process
-echo -e "\n${YELLOW}Starting background worker...${NC}"
-uv run python -m src.worker > logs/worker.log 2>&1 &
-WORKER_PID=$!
-echo "Worker PID: $WORKER_PID"
+# Start worker process (skip in read-only mode)
+if [ "$READ_ONLY" = false ]; then
+    echo -e "\n${YELLOW}Starting background worker...${NC}"
+    uv run python -m src.worker > logs/worker.log 2>&1 &
+    WORKER_PID=$!
+    echo "Worker PID: $WORKER_PID"
+else
+    echo -e "\n${YELLOW}Skipping background worker (read-only mode)${NC}"
+    WORKER_PID=""
+fi
 
 # Start Web UI
 echo -e "\n${YELLOW}Starting Web UI on port 12001...${NC}"
@@ -166,21 +198,38 @@ wait_for_service "Web UI" "curl -s http://localhost:12001 >/dev/null 2>&1"
 
 # Create PID file for cleanup
 echo "API_PID=$API_PID" > .dev_pids
-echo "WORKER_PID=$WORKER_PID" >> .dev_pids
+if [ "$WORKER_PID" != "" ]; then
+    echo "WORKER_PID=$WORKER_PID" >> .dev_pids
+fi
 echo "WEB_PID=$WEB_PID" >> .dev_pids
 
 # Success message
-echo -e "\n${GREEN}✅ All services started successfully!${NC}"
-echo -e "\n${GREEN}Services running:${NC}"
-echo "  - Redis: localhost:6379"
-echo "  - API Backend: http://localhost:12000"
-echo "  - API Docs: http://localhost:12000/docs"
-echo "  - Worker: Processing tasks in background"
-echo "  - Web UI: http://localhost:12001"
-echo -e "\n${YELLOW}Logs:${NC}"
-echo "  - API: logs/api.log"
-echo "  - Worker: logs/worker.log"
-echo "  - Web UI: logs/web.log"
+if [ "$READ_ONLY" = true ]; then
+    echo -e "\n${GREEN}✅ Read-only development services started successfully!${NC}"
+    echo -e "\n${GREEN}Services running:${NC}"
+    echo "  - PostgreSQL: localhost:5432"
+    echo "  - API Backend: http://localhost:12000"
+    echo "  - API Docs: http://localhost:12000/docs"
+    echo "  - Web UI: http://localhost:12001"
+    echo -e "\n${YELLOW}Logs:${NC}"
+    echo "  - API: logs/api.log"
+    echo "  - Web UI: logs/web.log"
+    echo -e "\n${GREEN}Perfect for viewing imported data and frontend development!${NC}"
+    echo -e "${YELLOW}Note: Import your database with 'python scripts/import_data.py' for realistic data${NC}"
+else
+    echo -e "\n${GREEN}✅ All services started successfully!${NC}"
+    echo -e "\n${GREEN}Services running:${NC}"
+    echo "  - Redis: localhost:6379"
+    echo "  - PostgreSQL: localhost:5432"
+    echo "  - API Backend: http://localhost:12000"
+    echo "  - API Docs: http://localhost:12000/docs"
+    echo "  - Worker: Processing tasks in background"
+    echo "  - Web UI: http://localhost:12001"
+    echo -e "\n${YELLOW}Logs:${NC}"
+    echo "  - API: logs/api.log"
+    echo "  - Worker: logs/worker.log"
+    echo "  - Web UI: logs/web.log"
+fi
 echo -e "\n${YELLOW}To stop all services, run:${NC} ./scripts/stop_dev.sh"
 
 # Keep script running and show logs

--- a/scripts/stop_dev.sh
+++ b/scripts/stop_dev.sh
@@ -51,14 +51,23 @@ fi
 
 # Stop Redis automatically
 echo "Stopping Redis..."
-if docker ps | grep "nexus-agents-redis-1\|nexus-redis" >/dev/null 2>&1; then
+if docker ps | grep "nexus-agents-redis-1" >/dev/null 2>&1; then
     echo "Stopping Redis Docker container..."
-    docker compose stop redis >/dev/null 2>&1 || docker stop nexus-redis >/dev/null 2>&1 || true
+    docker compose stop redis >/dev/null 2>&1 || true
 elif pgrep redis-server >/dev/null 2>&1; then
     echo "Stopping local Redis server..."
     redis-cli shutdown >/dev/null 2>&1
 else
     echo "No Redis instance found"
+fi
+
+# Stop PostgreSQL automatically
+echo "Stopping PostgreSQL..."
+if docker ps | grep "nexus-agents-postgres-1" >/dev/null 2>&1; then
+    echo "Stopping PostgreSQL Docker container..."
+    docker compose stop postgres >/dev/null 2>&1 || true
+else
+    echo "No PostgreSQL container found"
 fi
 
 echo -e "\n${GREEN} All services stopped!${NC}"


### PR DESCRIPTION
    - Add data export/import scripts for frontend development without API keys
    - Add read-only mode to start_dev.sh (DB + API + frontend only, no workers)
    - Fix Docker container grouping under nexus-agents project
    - Update stop script to always stop all containers by default
    - Add comprehensive frontend development documentation
    - Remove obsolete docker-compose version field
    - Add mock API server for alternative frontend development workflow
    
    This enables frontend engineers to work with realistic imported data
    without requiring LLM API keys, Redis workers, or MCP servers.